### PR TITLE
DPI-2195 Package rprotobuf in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -12,8 +12,8 @@ pkgs.rPackages.buildRPackage {
     paper (2016, <doi:10.18637/jss.v071.i02>. Either version 2 or 3 of the
     'Protocol Buffers' 'API' is supported.
   '';
+  nativeBuildInputs = with pkgs.rPackages; [ Rcpp ] ++ [ pkgs.protobuf3_12 ];
   propagatedBuildInputs = with pkgs.rPackages; [ 
     RCurl
-    Rcpp
   ];
 }

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,19 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "RProtoBuf";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = ''
+    Protocol Buffers are a way of encoding structured data in an
+    efficient yet extensible format. Google uses Protocol Buffers for almost all
+    of its internal 'RPC' protocols and file formats.  Additional documentation
+    is available in two included vignettes one of which corresponds to our 'JSS'
+    paper (2016, <doi:10.18637/jss.v071.i02>. Either version 2 or 3 of the
+    'Protocol Buffers' 'API' is supported.
+  '';
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    RCurl
+    Rcpp
+  ];
+}


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package rprotobuf in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR